### PR TITLE
In-graph-tracing PR feedback

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -138,9 +138,6 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
   componentDidMount() {
     const cy = this.getCy();
     this.cyInitialization(cy);
-    if (this.props.trace) {
-      showTrace(cy, this.props.trace);
-    }
   }
 
   shouldComponentUpdate(nextProps: CytoscapeGraphProps) {

--- a/src/components/CytoscapeGraph/CytoscapeTrace.ts
+++ b/src/components/CytoscapeGraph/CytoscapeTrace.ts
@@ -1,103 +1,95 @@
 import * as Cy from 'cytoscape';
 import { CyNode } from './CytoscapeGraphUtils';
-import { NodeType } from '../../types/Graph';
 import { JaegerTrace, Span } from 'types/JaegerInfo';
-import { getWorkloadFromSpan, searchParentWorkload } from 'components/JaegerIntegration/JaegerHelper';
-
-const getKeyAndType = (node: Cy.NodeSingular) => {
-  const namespace = node.data(CyNode.namespace);
-  const nodeType = node.data(CyNode.nodeType);
-  let key: string | undefined;
-  switch (nodeType) {
-    case NodeType.SERVICE:
-      key = node.data(CyNode.service) + '.' + namespace;
-      break;
-    case NodeType.WORKLOAD:
-      key = node.data(CyNode.workload) + '.' + namespace;
-      break;
-    case NodeType.APP:
-      // Note: it may only work for workloads named using the conventional "$name-$version".
-      // If this convention is not used, only service nodes will be highlighted for traces in app-versioned graph.
-      key = node.data(CyNode.app) + '-' + node.data(CyNode.version) + '.' + namespace;
-      break;
-  }
-  if (key) {
-    return {
-      key: key,
-      type: nodeType
-    };
-  }
-  return undefined;
-};
-
-const addToMap = (key: string, map: Map<String, Span[]>, span: Span) => {
-  let spans = map.get(key);
-  if (!spans) {
-    spans = [];
-    map.set(key, spans);
-  }
-  spans.push(span);
-};
+import {
+  getWorkloadFromSpan,
+  searchParentWorkload as getParentWorkloadFromSpan
+} from 'components/JaegerIntegration/JaegerHelper';
+import { NodeType } from 'types/Graph';
 
 export const showTrace = (cy: Cy.Core, trace: JaegerTrace) => {
   if (!cy) {
     return;
   }
-  const spansPerService = new Map<String, Span[]>();
-  const spansPerWorkload = new Map<String, Span[]>();
-  const spansPerEdge = new Map<String, Span[]>();
+
+  cy.startBatch();
+  hideTrace(cy);
+
   trace.spans.forEach(span => {
-    // TODO: namespace should be added to map key when it's not present (it's not mandatory in tracing)
-    addToMap(span.process.serviceName, spansPerService, span);
-    const workloadNs = getWorkloadFromSpan(span);
-    if (workloadNs) {
-      addToMap(workloadNs.workload + '.' + workloadNs.namespace, spansPerWorkload, span);
-      addToMap(span.process.serviceName + '~' + workloadNs.workload + '.' + workloadNs.namespace, spansPerEdge, span);
+    const split = span.process.serviceName.split('.');
+    const service = split[0];
+    // TODO: add ns when missing
+    let selector = `[${CyNode.nodeType}="${NodeType.SERVICE}"][${CyNode.service}="${service}"]`;
+    selector = split.length > 1 ? `${selector}[${CyNode.namespace}="${split[1]}"]` : selector;
+    const serviceSelection = cy.elements(selector);
+    if (!!serviceSelection) {
+      const serviceNode = singleNode(serviceSelection);
+      addSpan(serviceNode, span);
     }
-    const parentWkdNs = searchParentWorkload(span);
-    if (parentWkdNs) {
-      addToMap(parentWkdNs.workload + '.' + parentWkdNs.namespace + '~' + span.process.serviceName, spansPerEdge, span);
+
+    const sourceWlNs = getParentWorkloadFromSpan(span);
+    let sourceWlSelection: any;
+    if (sourceWlNs) {
+      const selector = `node[${CyNode.workload}="${sourceWlNs.workload}"][${CyNode.namespace}="${sourceWlNs.namespace}"]`;
+      sourceWlSelection = !!serviceSelection ? serviceSelection.incomers(selector) : cy.elements(selector);
+      if (!!sourceWlSelection) {
+        addSpan(singleNode(sourceWlSelection), span);
+        if (!!serviceSelection) {
+          addSpan(singleEdge(sourceWlSelection.edgesTo(serviceSelection)), span);
+        }
+      }
+    }
+
+    const destWlNs = getWorkloadFromSpan(span);
+    let destWlSelection: any;
+    if (destWlNs) {
+      const selector = `node[${CyNode.workload}="${destWlNs.workload}"][${CyNode.namespace}="${destWlNs.namespace}"]`;
+      destWlSelection = !!serviceSelection ? serviceSelection.outgoers(selector) : cy.elements(selector);
+      if (!!destWlSelection) {
+        addSpan(singleNode(destWlSelection), span);
+        if (!!serviceSelection) {
+          addSpan(singleEdge(serviceSelection.edgesTo(destWlSelection)), span);
+        }
+      }
     }
   });
 
-  // TODO: replace with node selectors
-  cy.nodes().forEach(ele => {
-    ele.data('spans', null);
-    const keyAndType = getKeyAndType(ele);
-    if (!keyAndType) {
-      return;
-    }
-    switch (keyAndType.type) {
-      case NodeType.SERVICE:
-        ele.data('spans', spansPerService.get(keyAndType.key));
-        break;
-      case NodeType.WORKLOAD:
-      case NodeType.APP:
-        ele.data('spans', spansPerWorkload.get(keyAndType.key));
-        break;
-    }
-  });
+  cy.endBatch();
+};
 
-  // TODO: replace with edge selectors
-  cy.edges().forEach(edge => {
-    edge.data('spans', null);
-    const sourceKeyType = getKeyAndType(edge.source());
-    const destKeyType = getKeyAndType(edge.target());
-    if (sourceKeyType && destKeyType) {
-      const fullKey = sourceKeyType.key + '~' + destKeyType.key;
-      edge.data('spans', spansPerEdge.get(fullKey));
-    }
-  });
+const singleEdge = (edges: Cy.EdgeCollection): Cy.EdgeSingular | undefined => {
+  if (edges.length > 1) {
+    console.debug(`Expected singleton, found [${edges.length}] edges. Using first.`);
+  }
+  return edges.length > 0 ? edges[0] : undefined;
+};
+
+const singleNode = (nodes: Cy.NodeCollection): Cy.NodeSingular | undefined => {
+  if (nodes.length > 1) {
+    console.debug(`Expected singleton, found [${nodes.length}] nodes. Using first.`);
+  }
+  return nodes.length > 0 ? nodes[0] : undefined;
+};
+
+const addSpan = (ele: Cy.NodeSingular | Cy.EdgeSingular | undefined, span: Span): void => {
+  if (!ele) {
+    return;
+  }
+
+  if (ele.hasClass('span')) {
+    ele.data('spans').push(span);
+  } else {
+    ele.addClass('span');
+    ele.data('spans', [span]);
+  }
 };
 
 export const hideTrace = (cy: Cy.Core) => {
   if (!cy) {
     return;
   }
-  cy.nodes().forEach(ele => {
-    ele.data('spans', null);
-  });
-  cy.edges().forEach(ele => {
-    ele.data('spans', null);
-  });
+  // unhighlight old span-hits
+  const spanHits = cy.elements('*.span');
+  spanHits.removeClass('span');
+  spanHits.data('spans', undefined);
 };

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -277,9 +277,6 @@ export class GraphStyles {
     };
 
     const getEdgeColor = (ele: Cy.EdgeSingular): string => {
-      if (ele.data('spans')) {
-        return PfColors.Blue700;
-      }
       let rate = 0;
       let pErr = 0;
       const edgeData = decoratedEdgeData(ele);
@@ -437,9 +434,6 @@ export class GraphStyles {
     };
 
     const getNodeBorderColor = (ele: Cy.NodeSingular): string => {
-      if (ele.data('spans')) {
-        return PfColors.Blue700;
-      }
       if (ele.hasClass(DEGRADED.name)) {
         return NodeColorBorderDegraded;
       }
@@ -625,6 +619,14 @@ export class GraphStyles {
         selector: '*.find[^isGroup]',
         style: {
           'overlay-color': PfColors.Gold400,
+          'overlay-padding': '8px',
+          'overlay-opacity': 0.5
+        }
+      },
+      {
+        selector: '*.span[^isGroup]',
+        style: {
+          'overlay-color': PfColors.Purple200,
           'overlay-padding': '8px',
           'overlay-opacity': 0.5
         }

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -350,6 +350,10 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
       this.errorBoundaryRef.current.cleanError();
     }
 
+    if (prev.summaryData !== this.props.summaryData) {
+      this.props.setTraceId(undefined);
+    }
+
     if (curr.showLegend && this.props.activeTour) {
       this.props.endTour();
     }


### PR DESCRIPTION
@jotak This PR does things differently although whether it's better I'm not sure.  I think maybe it's a little easier to follow the logic, and maybe a little more efficient.  I'd probably recomment a DO NOT MERGE until at least it's tested against the original to ensure it's behaving the same way.  Actually, we probably should have a short meeting to talk a little more about a few behavioral items.

- change to single-pass approach for mapping trace to graph and use cy class for quick id/clear of the affected elems
- change to find-like highlighting
- get rid of the trace when the trace tab goes away
- defer showing trace until graph is ready (mount -> update)
